### PR TITLE
fix: remove statusCode getter to prevent 404

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "express-to-koa",
-  "version": "1.0.6",
+  "name": "e2k",
+  "version": "1.0.0",
   "description": "Use express middlewares in Koa2, the one that really works.",
   "main": "lib/index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/kaelzhang/express-to-koa.git"
+    "url": "git://github.com/cuiyongjian/express-to-koa.git"
   },
   "keywords": [
     "express-to-koa",
@@ -24,10 +24,10 @@
   "engines": {
     "node": ">=4"
   },
-  "author": "kaelzhang",
+  "author": "sheldoncui",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kaelzhang/express-to-koa/issues"
+    "url": "https://github.com/cuiyongjian/express-to-koa/issues"
   },
   "ava": {
     "require": "babel-register",

--- a/src/index.js
+++ b/src/index.js
@@ -1,51 +1,73 @@
-const properties = {
+"use strict";
+
+var properties = {
+  statusCode: {
+    get: function get() {
+      return this._response.statusCode;
+    },
+    set: function set(code) {
+      this._response.statusCode = code;
+    }
+  },
+
+  writeHead: {
+    value: function value() {
+      var _response;
+      (_response = this._response).writeHead.apply(_response, arguments);
+    }
+  },
+
   write: {
-    value (...args) {
+    value: function value() {
+      var _response2;
+
       // Koa and Koa2 set the statusCode to `404` by default.
       // So we must do something as well as `ctx.body = body`.
       if (!this._explicitStatus) {
         // set to _response.statusCode
-        this.statusCode = 200
+        this.statusCode = 200;
       }
 
-      return this._response.write(...args)
+      return (_response2 = this._response).write.apply(_response2, arguments);
     }
   },
 
   end: {
-    value (...args) {
+    value: function value() {
+      var _response3;
+
       if (!this._explicitStatus) {
-        this.statusCode = 200
+        this.statusCode = 200;
       }
 
-      return this._response.end(...args)
+      return (_response3 = this._response).end.apply(_response3, arguments);
     }
   }
-}
+};
 
-
-function makeResponse (res) {
+function makeResponse(res) {
   return Object.create({
     __proto__: res,
-    _response: res
-  }, properties)
+    _response: res,
+
+  }, properties);
 }
 
-
-function wrap (ctx, middleware, next) {
-  return new Promise((resolve, reject) => {
-    middleware(ctx.req, makeResponse(ctx.res), err => {
+function wrap(ctx, middleware, next) {
+  return new Promise(function (resolve, reject) {
+    middleware(ctx.req, makeResponse(ctx.res), function (err) {
       if (err) {
-        reject(err)
-        return
+        reject(err);
+        return;
       }
 
-      resolve(next())
-    })
-  })
+      resolve(next());
+    });
+  });
 }
 
-
-module.exports = function e2k (middleware) {
-  return (ctx, next) => wrap(ctx, middleware, next)
-}
+module.exports = function e2k(middleware) {
+  return function (ctx, next) {
+    return wrap(ctx, middleware, next);
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,4 @@
 const properties = {
-  statusCode: {
-    get () {
-      return this._response.statusCode
-    },
-
-    set (code) {
-      this._explicitStatus = true
-      this._response.statusCode = code
-    }
-  },
-
-  writeHead: {
-    value (...args) {
-      this._explicitStatus = true
-      this._response.writeHead(...args)
-    }
-  },
-
   write: {
     value (...args) {
       // Koa and Koa2 set the statusCode to `404` by default.


### PR DESCRIPTION
Because of the [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware/blob/master/lib/middleware.js) has set the `res.statusCode` with the original res.statusCode like the floowing code:

```js
// Express automatically sets the statusCode to 200, but not all servers do (Koa).
res.statusCode = res.statusCode || 200;
```

so, i think, the `express-to-koa` should not  to reset the `res.statusCode` with a getter.  

for example, now, the express-to-koa set the res.statusCode with:

```js
  statusCode: {
    get () {
      return this._response.statusCode
    },

    set (code) {
      this._explicitStatus = true
      this._response.statusCode = code
    }
  },
```

Based on that, when the `webpack-dev-middleware` doing the `res.statusCode = res.statusCode || 200;`,  it will invoke the getter, and get the Koa default statusCode: 404.    And meanwhile, the setter weill be invoked to set the `res._explicitStatus` with `true`.

Finally,  the `res.end` will hard  to set the status with 200  (because the _explicitStatus is true).

```js
  end: {
    value (...args) {
      if (!this._explicitStatus) {
        this.statusCode = 200
      }

      return this._response.end(...args)
    }
  }
```

But now, the result code is 404.

----------------

if find two solution which is :
1. to change the status getter to be return `undefined`.
Because the undefined statussCode will let the webpack-dev-middleware to use 200. and meanwhilt it will invoke setter to set the _explicitStatus to true.
2. to remove the statusCode getter and setter.  i think this will always let the express-middleware status to be 404.  But when is invoke `res.end`,  we will set the status to 200 because of the `_explicitStatus=false`


i try to study the `[koa-webpack](https://github.com/shellscape/koa-webpack/blob/master/lib/middleware.js)` package's implementation，is use the koa context to implement the `res.end`, its also a simple way:

```js
end: (content) => {
              // eslint-disable-next-line no-param-reassign
              context.body = content;
              resolve();
            },
```

